### PR TITLE
Feature/QE-261 - Add tests for CS snippets

### DIFF
--- a/manage-payments/cs/cancel.cs
+++ b/manage-payments/cs/cancel.cs
@@ -1,2 +1,2 @@
 var paymentIntentsClient = new PaymentIntentsClient(new HttpClient(), new ApiKeyClientAuthorization("sk_sandbox_c8oLGaI__msxsXbpBDpdtwJEz_eIhfQoKHmedqgZPCdBx59zpKZLSk8OPLT0cZolbeuYJSBvzDVVsYvtpo5RkQ"));
-paymentIntentsClient.DeleteAsync("<PAYMENT_INTENT_ID>");
+var result = await paymentIntentsClient.DeleteAsync("<PAYMENT_INTENT_ID>");

--- a/manage-payments/cs/capture.cs
+++ b/manage-payments/cs/capture.cs
@@ -1,5 +1,5 @@
 var capturesClient = new Dojo.Net.CapturesClient(new HttpClient(), new ApiKeyClientAuthorization("sk_sandbox_c8oLGaI__msxsXbpBDpdtwJEz_eIhfQoKHmedqgZPCdBx59zpKZLSk8OPLT0cZolbeuYJSBvzDVVsYvtpo5RkQ"));
-capturesClient.CreateAsync("<PAYMENT_INTENT_ID>", new CreateCaptureRequest
+var result = await capturesClient.CreateAsync("<PAYMENT_INTENT_ID>", new CreateCaptureRequest
 {
     Amount = 1000
 });

--- a/manage-payments/cs/change-amount.cs
+++ b/manage-payments/cs/change-amount.cs
@@ -1,2 +1,2 @@
 var paymentIntentsClient = new PaymentIntentsClient(new HttpClient(), new ApiKeyClientAuthorization("sk_sandbox_c8oLGaI__msxsXbpBDpdtwJEz_eIhfQoKHmedqgZPCdBx59zpKZLSk8OPLT0cZolbeuYJSBvzDVVsYvtpo5RkQ"));
-paymentIntentsClient.SetCustomAmountAsync("<PAYMENT_INTENT_ID>", new SetAmountRequest{Amount = new Money {Value = 500, CurrencyCode = "GBP"}});
+var result = await paymentIntentsClient.SetCustomAmountAsync("<PAYMENT_INTENT_ID>", new SetAmountRequest{Amount = new Money {Value = 500, CurrencyCode = "GBP"}});

--- a/manage-payments/cs/change-tips-amount.cs
+++ b/manage-payments/cs/change-tips-amount.cs
@@ -1,2 +1,2 @@
 var paymentIntentsClient = new PaymentIntentsClient(new HttpClient(), new ApiKeyClientAuthorization("sk_sandbox_c8oLGaI__msxsXbpBDpdtwJEz_eIhfQoKHmedqgZPCdBx59zpKZLSk8OPLT0cZolbeuYJSBvzDVVsYvtpo5RkQ"));
-paymentIntentsClient.SetTipsAmountAsync("<PAYMENT_INTENT_ID>", new SetTipsAmountRequest{TipsAmount = new Money {Value = 200, CurrencyCode = "GBP"}});
+var result = await paymentIntentsClient.SetTipsAmountAsync("<PAYMENT_INTENT_ID>", new SetTipsAmountRequest{TipsAmount = new Money {Value = 200, CurrencyCode = "GBP"}});

--- a/manage-payments/cs/retrieve.cs
+++ b/manage-payments/cs/retrieve.cs
@@ -1,5 +1,3 @@
-using Dojo.Net;
-
 var paymentIntentsClient = new PaymentIntentsClient(new HttpClient(), new ApiKeyClientAuthorization("sk_sandbox_c8oLGaI__msxsXbpBDpdtwJEz_eIhfQoKHmedqgZPCdBx59zpKZLSk8OPLT0cZolbeuYJSBvzDVVsYvtpo5RkQ"));
-var result = await paymentIntentsClient.GetAsync("pi_sandbox_LQFTlEHlJk6F0aShXPOG2Q");
+var result = await paymentIntentsClient.GetAsync("<PAYMENT_INTENT_ID>");
 Console.Write(result.Status);

--- a/manage-payments/cs/reversal.cs
+++ b/manage-payments/cs/reversal.cs
@@ -1,2 +1,2 @@
 var reversalClient = new ReversalClient(new HttpClient(), new ApiKeyClientAuthorization("sk_sandbox_c8oLGaI__msxsXbpBDpdtwJEz_eIhfQoKHmedqgZPCdBx59zpKZLSk8OPLT0cZolbeuYJSBvzDVVsYvtpo5RkQ"));
-reversalClient.CreateAsync("<PAYMENT_INTENT_ID>");
+var result = await reversalClient.CreateAsync("<PAYMENT_INTENT_ID>");

--- a/tests/cs/DojoSamples.Tests/DojoSamples.Tests.csproj
+++ b/tests/cs/DojoSamples.Tests/DojoSamples.Tests.csproj
@@ -1,0 +1,26 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+
+    <IsPackable>false</IsPackable>
+
+    <RootNamespace>DojoSamples.Tests</RootNamespace>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="CS-Script" Version="4.4.6" />
+    <PackageReference Include="Dojo.Net" Version="1.0.7" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.9.4" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="coverlet.collector" Version="3.0.2">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
+  </ItemGroup>
+
+</Project>

--- a/tests/cs/DojoSamples.Tests/configuration/add-payment-methods.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/add-payment-methods.cs
@@ -1,0 +1,18 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.configuration
+{
+    public class AddPaymentMethodsTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/add-payment-methods.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script);
+            Assert.True(result.Id.Length  > 0, "Expected a payment intent id in response");
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/configuration/add-payment-methods.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/add-payment-methods.cs
@@ -10,8 +10,7 @@ namespace DojoSamples.Tests.configuration
         [Fact]
         public async void TestSnippet()
         {
-            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/add-payment-methods.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script);
+            PaymentIntent result = await CodeSnippet.Run("configuration/cs/add-payment-methods.cs");
             Assert.True(result.Id.Length  > 0, "Expected a payment intent id in response");
         }
     }

--- a/tests/cs/DojoSamples.Tests/configuration/billing-and-shipping-details.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/billing-and-shipping-details.cs
@@ -10,8 +10,7 @@ namespace DojoSamples.Tests.configuration
         [Fact]
         public async void TestSnippet()
         {
-            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/billing-and-shipping-details.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script);
+            PaymentIntent result = await CodeSnippet.Run("configuration/cs/billing-and-shipping-details.cs");
             Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
         }
     }

--- a/tests/cs/DojoSamples.Tests/configuration/billing-and-shipping-details.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/billing-and-shipping-details.cs
@@ -1,0 +1,18 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.configuration
+{
+    public class BillingAndShippingDetailsTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/billing-and-shipping-details.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script);
+            Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/configuration/redirect-success-page.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/redirect-success-page.cs
@@ -1,0 +1,18 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.configuration
+{
+    public class RedirectSuccessPageTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/redirect-success-page.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script);
+            Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/configuration/redirect-success-page.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/redirect-success-page.cs
@@ -10,8 +10,7 @@ namespace DojoSamples.Tests.configuration
         [Fact]
         public async void TestSnippet()
         {
-            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/redirect-success-page.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script);
+            PaymentIntent result = await CodeSnippet.Run("configuration/cs/redirect-success-page.cs");
             Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
         }
     }

--- a/tests/cs/DojoSamples.Tests/configuration/show-information.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/show-information.cs
@@ -10,8 +10,7 @@ namespace DojoSamples.Tests.configuration
         [Fact]
         public async void TestSnippet()
         {
-            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/show-information.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script);
+            PaymentIntent result = await CodeSnippet.Run("configuration/cs/show-information.cs");
             Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
         }
     }

--- a/tests/cs/DojoSamples.Tests/configuration/show-information.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/show-information.cs
@@ -1,0 +1,18 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.configuration
+{
+    public class ShowInformationTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/show-information.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script);
+            Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/configuration/show-title.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/show-title.cs
@@ -1,0 +1,18 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.configuration
+{
+    public class ShowTitleTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/show-title.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script);
+            Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/configuration/show-title.cs
+++ b/tests/cs/DojoSamples.Tests/configuration/show-title.cs
@@ -10,8 +10,7 @@ namespace DojoSamples.Tests.configuration
         [Fact]
         public async void TestSnippet()
         {
-            var script = Path.GetRelativePath(".", "../../../../../../configuration/cs/show-title.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script);
+            PaymentIntent result = await CodeSnippet.Run("configuration/cs/show-title.cs");
             Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
         }
     }

--- a/tests/cs/DojoSamples.Tests/getting-started/create-payment-intent.cs
+++ b/tests/cs/DojoSamples.Tests/getting-started/create-payment-intent.cs
@@ -1,0 +1,18 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.getting_started
+{
+    public class CreatePaymentIntentTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var script = Path.GetRelativePath(".", "../../../../../../getting-started/cs/create-payment-intent.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script);
+            Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/getting-started/create-payment-intent.cs
+++ b/tests/cs/DojoSamples.Tests/getting-started/create-payment-intent.cs
@@ -10,8 +10,7 @@ namespace DojoSamples.Tests.getting_started
         [Fact]
         public async void TestSnippet()
         {
-            var script = Path.GetRelativePath(".", "../../../../../../getting-started/cs/create-payment-intent.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script);
+            PaymentIntent result = await CodeSnippet.Run("getting-started/cs/create-payment-intent.cs");
             Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
         }
     }

--- a/tests/cs/DojoSamples.Tests/manage-payments/cancel.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/cancel.cs
@@ -1,0 +1,23 @@
+using System;
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.manage_payments
+{
+    public class CancelPaymentTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var paymentIntent = await Intent.CreateIntent();
+            Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
+            
+            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/cancel.cs");
+            var result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            Assert.Equal(result.Id, paymentIntent.Id);
+            Assert.Equal("Canceled", result.Status.ToString());
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/manage-payments/cancel.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/cancel.cs
@@ -14,8 +14,7 @@ namespace DojoSamples.Tests.manage_payments
             var paymentIntent = await Intent.CreateIntent();
             Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
             
-            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/cancel.cs");
-            var result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            var result = await CodeSnippet.Run("manage-payments/cs/cancel.cs", paymentIntent.Id);
             Assert.Equal(result.Id, paymentIntent.Id);
             Assert.Equal("Canceled", result.Status.ToString());
         }

--- a/tests/cs/DojoSamples.Tests/manage-payments/capture.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/capture.cs
@@ -1,0 +1,22 @@
+using System;
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.manage_payments
+{
+    public class CaptureTest
+    {
+        [Fact(Skip="ignore because a payment with status Created cannot be Captured")]
+        public async void TestSnippet()
+        {
+            var paymentIntent = await Intent.CreateIntent();
+            Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
+            
+            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/capture.cs");
+            Capture result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            Assert.True(result.CaptureId.Length > 0, "Expected capture ID");
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/manage-payments/capture.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/capture.cs
@@ -14,8 +14,7 @@ namespace DojoSamples.Tests.manage_payments
             var paymentIntent = await Intent.CreateIntent();
             Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
             
-            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/capture.cs");
-            Capture result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            Capture result = await CodeSnippet.Run("manage-payments/cs/capture.cs", paymentIntent.Id);
             Assert.True(result.CaptureId.Length > 0, "Expected capture ID");
         }
     }

--- a/tests/cs/DojoSamples.Tests/manage-payments/change-amount.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/change-amount.cs
@@ -13,8 +13,8 @@ namespace DojoSamples.Tests.manage_payments
             var paymentIntent = await Intent.CreateIntent();
             Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
             
-            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/change-amount.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            var script = Path.GetRelativePath(".", "../../../../../../");
+            PaymentIntent result = await CodeSnippet.Run("manage-payments/cs/change-amount.cs", paymentIntent.Id);
             Assert.True(result.Id.Length > 0, "Expected payment intent ID");
             Assert.Equal("Created", result.Status.ToString());
             Assert.Equal(500, result.Amount.Value);

--- a/tests/cs/DojoSamples.Tests/manage-payments/change-amount.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/change-amount.cs
@@ -13,7 +13,6 @@ namespace DojoSamples.Tests.manage_payments
             var paymentIntent = await Intent.CreateIntent();
             Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
             
-            var script = Path.GetRelativePath(".", "../../../../../../");
             PaymentIntent result = await CodeSnippet.Run("manage-payments/cs/change-amount.cs", paymentIntent.Id);
             Assert.True(result.Id.Length > 0, "Expected payment intent ID");
             Assert.Equal("Created", result.Status.ToString());

--- a/tests/cs/DojoSamples.Tests/manage-payments/change-amount.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/change-amount.cs
@@ -1,0 +1,23 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.manage_payments
+{
+    public class ChangeAmountTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var paymentIntent = await Intent.CreateIntent();
+            Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
+            
+            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/change-amount.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            Assert.True(result.Id.Length > 0, "Expected payment intent ID");
+            Assert.Equal("Created", result.Status.ToString());
+            Assert.Equal(500, result.Amount.Value);
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/manage-payments/change-tips-amount.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/change-tips-amount.cs
@@ -13,8 +13,8 @@ namespace DojoSamples.Tests.manage_payments
             var paymentIntent = await Intent.CreateIntent();
             Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
             
-            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/change-tips-amount.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            var script = Path.GetRelativePath(".", "../../../../../../");
+            PaymentIntent result = await CodeSnippet.Run("manage-payments/cs/change-tips-amount.cs", paymentIntent.Id);
             Assert.True(result.Id.Length > 0, "Expected payment intent ID");
             Assert.Equal("Created", result.Status.ToString());
             Assert.Equal(200, result.TipsAmount.Value);

--- a/tests/cs/DojoSamples.Tests/manage-payments/change-tips-amount.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/change-tips-amount.cs
@@ -1,0 +1,23 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.manage_payments
+{
+    public class ChangeTipsAmountTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var paymentIntent = await Intent.CreateIntent();
+            Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
+            
+            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/change-tips-amount.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            Assert.True(result.Id.Length > 0, "Expected payment intent ID");
+            Assert.Equal("Created", result.Status.ToString());
+            Assert.Equal(200, result.TipsAmount.Value);
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/manage-payments/change-tips-amount.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/change-tips-amount.cs
@@ -13,7 +13,6 @@ namespace DojoSamples.Tests.manage_payments
             var paymentIntent = await Intent.CreateIntent();
             Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
             
-            var script = Path.GetRelativePath(".", "../../../../../../");
             PaymentIntent result = await CodeSnippet.Run("manage-payments/cs/change-tips-amount.cs", paymentIntent.Id);
             Assert.True(result.Id.Length > 0, "Expected payment intent ID");
             Assert.Equal("Created", result.Status.ToString());

--- a/tests/cs/DojoSamples.Tests/manage-payments/retrieve.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/retrieve.cs
@@ -13,8 +13,7 @@ namespace DojoSamples.Tests.manage_payments
             var paymentIntent = await Intent.CreateIntent();
             Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
             
-            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/retrieve.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            PaymentIntent result = await CodeSnippet.Run("manage-payments/cs/retrieve.cs", paymentIntent.Id);
             Assert.True(result.Id.Length > 0, "Expected payment intent ID");
             Assert.Equal("Created", result.Status.ToString());
         }

--- a/tests/cs/DojoSamples.Tests/manage-payments/retrieve.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/retrieve.cs
@@ -1,0 +1,22 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.manage_payments
+{
+    public class RetrieveTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var paymentIntent = await Intent.CreateIntent();
+            Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
+            
+            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/retrieve.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            Assert.True(result.Id.Length > 0, "Expected payment intent ID");
+            Assert.Equal("Created", result.Status.ToString());
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/manage-payments/reversal.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/reversal.cs
@@ -1,0 +1,21 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.manage_payments
+{
+    public class ReversalTest
+    {
+        [Fact(Skip = "ignore because a payment with status Created cannot be Reversed")]
+        public async void TestSnippet()
+        {
+            var paymentIntent = await Intent.CreateIntent();
+            Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
+            
+            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/reversal.cs");
+            Reversal result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            Assert.True(result.ReversalId.Length > 0, "Expected reversal ID");
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/manage-payments/reversal.cs
+++ b/tests/cs/DojoSamples.Tests/manage-payments/reversal.cs
@@ -13,8 +13,7 @@ namespace DojoSamples.Tests.manage_payments
             var paymentIntent = await Intent.CreateIntent();
             Assert.True(paymentIntent.Id.Length > 0, "Expected payment intent to be created");
             
-            var script = Path.GetRelativePath(".", "../../../../../../manage-payments/cs/reversal.cs");
-            Reversal result = await new CodeSnippet().Run(script, paymentIntent.Id);
+            Reversal result = await CodeSnippet.Run("manage-payments/cs/reversal.cs", paymentIntent.Id);
             Assert.True(result.ReversalId.Length > 0, "Expected reversal ID");
         }
     }

--- a/tests/cs/DojoSamples.Tests/payment-intent/payment-intent-manual.cs
+++ b/tests/cs/DojoSamples.Tests/payment-intent/payment-intent-manual.cs
@@ -10,8 +10,7 @@ namespace DojoSamples.Tests.payment_intent
         [Fact]
         public async void TestSnippet()
         {
-            var script = Path.GetRelativePath(".", "../../../../../../payment-intent/cs/payment-intent-manual.cs");
-            PaymentIntent result = await new CodeSnippet().Run(script);
+            PaymentIntent result = await CodeSnippet.Run("payment-intent/cs/payment-intent-manual.cs");
             Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
             Assert.Equal("Manual", result.CaptureMode.ToString());
         }

--- a/tests/cs/DojoSamples.Tests/payment-intent/payment-intent-manual.cs
+++ b/tests/cs/DojoSamples.Tests/payment-intent/payment-intent-manual.cs
@@ -1,0 +1,19 @@
+using Dojo.Net;
+using Xunit;
+using System.IO;
+using DojoSamples.Tests.utils;
+
+namespace DojoSamples.Tests.payment_intent
+{
+    public class PaymentIntentManualTest
+    {
+        [Fact]
+        public async void TestSnippet()
+        {
+            var script = Path.GetRelativePath(".", "../../../../../../payment-intent/cs/payment-intent-manual.cs");
+            PaymentIntent result = await new CodeSnippet().Run(script);
+            Assert.True(result.Id.Length > 0, "Expected a payment intent id in response");
+            Assert.Equal("Manual", result.CaptureMode.ToString());
+        }
+    }
+}

--- a/tests/cs/DojoSamples.Tests/utils/CodeSnippet.cs
+++ b/tests/cs/DojoSamples.Tests/utils/CodeSnippet.cs
@@ -1,0 +1,39 @@
+using System.IO;
+using System.Threading.Tasks;
+using CSScriptLib;
+using Dojo.Net;
+
+namespace DojoSamples.Tests.utils
+{
+    public class CodeSnippet
+    {
+        public async Task<dynamic> Run(string script, string id = "")
+        {
+            var codeString = File.ReadAllText(script);
+
+            if (id.Length > 0)
+            {
+                codeString = codeString.Replace("<PAYMENT_INTENT_ID>", id);
+            }
+            
+            var code = @"using System;
+                                using System.Net.Http;
+                                using Dojo.Net;
+                                using System.Threading.Tasks;
+                                using DojoSamples.Tests.utils;
+                                using System.Collections.Generic;
+
+                                 public class Script : ISnippet
+                                 {
+                                     public async Task<dynamic> Run()
+                                     {
+                                         " + codeString + @"
+                                        return result;
+                                     }
+                                 }";
+
+            dynamic snippet = CSScript.Evaluator.LoadCode(code);
+            return await snippet.Run();
+        } 
+    }
+}

--- a/tests/cs/DojoSamples.Tests/utils/CodeSnippet.cs
+++ b/tests/cs/DojoSamples.Tests/utils/CodeSnippet.cs
@@ -5,11 +5,13 @@ using Dojo.Net;
 
 namespace DojoSamples.Tests.utils
 {
-    public class CodeSnippet
+    public static class CodeSnippet
     {
-        public async Task<dynamic> Run(string script, string id = "")
+        public static async Task<dynamic> Run(string script, string id = "")
         {
-            var codeString = File.ReadAllText(script);
+            var path = Path.GetRelativePath(".", $"../../../../../../{script}");
+
+            var codeString = File.ReadAllText(path);
 
             if (id.Length > 0)
             {

--- a/tests/cs/DojoSamples.Tests/utils/ISnippet.cs
+++ b/tests/cs/DojoSamples.Tests/utils/ISnippet.cs
@@ -1,0 +1,9 @@
+using System.Threading.Tasks;
+
+namespace DojoSamples.Tests.utils
+{
+    public interface ISnippet
+    {
+        public Task<dynamic> Run();
+    }
+}

--- a/tests/cs/DojoSamples.Tests/utils/Intent.cs
+++ b/tests/cs/DojoSamples.Tests/utils/Intent.cs
@@ -1,0 +1,33 @@
+using Dojo.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using DojoSamples.Tests.utils;
+using System.Collections.Generic;
+
+namespace DojoSamples.Tests.utils
+{
+    public static class Intent
+    {
+        public static async Task<PaymentIntent> CreateIntent() {
+            var paymentIntentsClient = new PaymentIntentsClient(new HttpClient(), new ApiKeyClientAuthorization("sk_sandbox_c8oLGaI__msxsXbpBDpdtwJEz_eIhfQoKHmedqgZPCdBx59zpKZLSk8OPLT0cZolbeuYJSBvzDVVsYvtpo5RkQ"));
+            return await paymentIntentsClient.CreatePaymentIntentAsync(new CreatePaymentIntentRequest
+            {
+                Amount = new()
+                {
+                    Value = 1000,
+                    CurrencyCode = "GBP"
+                },
+                Config = new()
+                {
+                    Payment = new PaymentConfigDetails()
+                    {
+                        CustomAmountAllowed = true,
+                        TipsAllowed = true
+                    }
+                },
+                PaymentMethods = new List<PaymentMethod>() { PaymentMethod.Card , PaymentMethod.Wallet},
+                Reference = "Order-0001"
+            });
+        }
+    }
+}

--- a/tests/cs/README.md
+++ b/tests/cs/README.md
@@ -1,0 +1,9 @@
+## Test Code Samples
+
+### C#
+
+```
+cd /tests/cs
+nuget restore
+dotnet test
+```

--- a/tests/cs/dojo-samples.sln
+++ b/tests/cs/dojo-samples.sln
@@ -1,0 +1,17 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+#
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "DojoSamples.Tests", "DojoSamples.Tests\DojoSamples.Tests.csproj", "{7915A8E5-A923-4E6B-8A50-97F9B8F07EC4}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{7915A8E5-A923-4E6B-8A50-97F9B8F07EC4}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7915A8E5-A923-4E6B-8A50-97F9B8F07EC4}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7915A8E5-A923-4E6B-8A50-97F9B8F07EC4}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7915A8E5-A923-4E6B-8A50-97F9B8F07EC4}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
Ticket:
https://paymentsense.atlassian.net/jira/software/c/projects/QE/boards/305?modal=detail&selectedIssue=QE-261

Summary of changes:

Add CS integration tests to check code snippets are valid
Update CS example snippets with a results object where needed
Remove hard coded payment intent id from retrieve.cs snippet

Update tests to match python implementation as per https://github.com/dojo-engineering/dojo-samples/pull/14

How to run:
See tests/cs/README.md