### PR TITLE
Fixed the bug with incorrect test cards link

### DIFF
--- a/samples/accept-a-payment/prebuilt-checkout/client/react-cra/src/components/Checkout.js
+++ b/samples/accept-a-payment/prebuilt-checkout/client/react-cra/src/components/Checkout.js
@@ -73,7 +73,7 @@ export const Checkout = ({ useSaveCards }) => {
                 Built-in payment page. To get the list of test cards 💳 go{" "}
                 <a
                   target="blank"
-                  href="https://docs.dojo.tech/payments/development-resources/testing"
+                  href="https://docs.dojo.tech/development-resources/testing"
                 >
                   here
                 </a>


### PR DESCRIPTION
Due to recent documentation portal changes, the link needed an update.