### PR TITLE
lowercase header name to be less error prone

### DIFF
--- a/webhooks/python/verify-webhooks.py
+++ b/webhooks/python/verify-webhooks.py
@@ -19,7 +19,7 @@ def webhook():
         print(event)
         # signature verification
         secret = "PDYkJQq6sESYHp_zJuTTBQ"
-        signatureHeader = request.header.get('Dojo-Signature')
+        signatureHeader = request.header.get('dojo-signature')
 
         signature = hmac.new(secret, str(payload))
 


### PR DESCRIPTION
Some HTTP server implementations (nodejs) will lowercase header names and only make them available via the lowercased name, therefore if they copy and paste the header name from this snippet then it will fail in their code.

Elsewhere we use `dojo-signature` lowercase so figured may as well update it here as well.

This python code supports the name being case insensitive (inline with the HTTP spec) - https://requests.readthedocs.io/en/latest/user/quickstart/#response-headers, so will work in either format